### PR TITLE
feat: add-material api

### DIFF
--- a/src/components/material/material-form/constants.ts
+++ b/src/components/material/material-form/constants.ts
@@ -2,13 +2,15 @@ import { type IFormData } from './types';
 
 export const initialValues: IFormData = {
   name: '',
-  materialNumber: '',
-  netoPrice: '',
-  mwSt: '',
-  weight: '',
-  customsTariff: '',
-  comment: '',
-  packaging: false,
-  attributes: [],
+  type: '',
   values: [],
+  attributes: [],
+  weight: undefined,
+  materialNumber: '',
+  netPrice: undefined,
+  VAT: undefined,
+  customsTarif: undefined,
+  description: '',
+  image: '',
+  packaging: false,
 };

--- a/src/components/material/material-form/material-form.tsx
+++ b/src/components/material/material-form/material-form.tsx
@@ -22,7 +22,7 @@ import { initialValues } from './constants';
 import { useStyles } from './styles';
 
 interface IMaterialFormProps {
-  onSubmit: (data: IFormData) => Promise<void>;
+  onSubmit: (data: IFormData) => void;
 }
 
 interface IFieldType {
@@ -51,8 +51,7 @@ const MaterialForm = forwardRef<HTMLFormElement, IMaterialFormProps>(
           <Box
             component="form"
             ref={ref}
-            onSubmit={(e: React.FormEvent<HTMLFormElement>): void => {
-              e.preventDefault();
+            onSubmit={(): void => {
               void methods.handleSubmit(onSubmit)();
             }}
             className={classes.formContainer}

--- a/src/components/material/material-form/material-form.tsx
+++ b/src/components/material/material-form/material-form.tsx
@@ -22,7 +22,18 @@ import { initialValues } from './constants';
 import { useStyles } from './styles';
 
 interface IMaterialFormProps {
-  onSubmit: (data: IFormData) => void;
+  onSubmit: (data: IFormData) => Promise<void>;
+}
+
+interface IFieldType {
+  onChange: (value: number) => void;
+}
+
+function handleNumberChange(
+  field: IFieldType,
+  e: React.ChangeEvent<HTMLInputElement>,
+): void {
+  field.onChange(Number.parseFloat(e.target.value));
 }
 
 const MaterialForm = forwardRef<HTMLFormElement, IMaterialFormProps>(
@@ -40,7 +51,10 @@ const MaterialForm = forwardRef<HTMLFormElement, IMaterialFormProps>(
           <Box
             component="form"
             ref={ref}
-            onSubmit={void methods.handleSubmit(onSubmit)}
+            onSubmit={(e: React.FormEvent<HTMLFormElement>): void => {
+              e.preventDefault();
+              void methods.handleSubmit(onSubmit)();
+            }}
             className={classes.formContainer}
           >
             <Box className={classes.inputRow}>
@@ -61,7 +75,7 @@ const MaterialForm = forwardRef<HTMLFormElement, IMaterialFormProps>(
             </Box>
             <Box className={classes.inputRow}>
               <Controller
-                name="netoPrice"
+                name="netPrice"
                 control={methods.control}
                 render={({ field }) => {
                   return (
@@ -72,12 +86,15 @@ const MaterialForm = forwardRef<HTMLFormElement, IMaterialFormProps>(
                       max={999_999_999}
                       label="Enter net price"
                       adornment="€"
+                      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                        return handleNumberChange(field as IFieldType, e);
+                      }}
                     />
                   );
                 }}
               />
               <Controller
-                name="mwSt"
+                name="VAT"
                 control={methods.control}
                 render={({ field }) => {
                   return (
@@ -88,6 +105,9 @@ const MaterialForm = forwardRef<HTMLFormElement, IMaterialFormProps>(
                       max={999_999_999}
                       label="Enter VAT"
                       adornment="%"
+                      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                        return handleNumberChange(field as IFieldType, e);
+                      }}
                     />
                   );
                 }}
@@ -106,12 +126,15 @@ const MaterialForm = forwardRef<HTMLFormElement, IMaterialFormProps>(
                       max={999_999_999}
                       label="Enter weight"
                       adornment="kg"
+                      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                        return handleNumberChange(field as IFieldType, e);
+                      }}
                     />
                   );
                 }}
               />
               <Controller
-                name="customsTariff"
+                name="customsTarif"
                 control={methods.control}
                 render={({ field }) => {
                   return <Input {...field} label="Enter customs tariff" />;
@@ -120,7 +143,7 @@ const MaterialForm = forwardRef<HTMLFormElement, IMaterialFormProps>(
             </Box>
             <Box className={classes.inputRow}>
               <Controller
-                name="comment"
+                name="description"
                 control={methods.control}
                 render={({ field }) => {
                   return (
@@ -212,7 +235,8 @@ const MaterialForm = forwardRef<HTMLFormElement, IMaterialFormProps>(
                       {field.value.map((value, index) => {
                         return (
                           <ValueRow
-                            key={value.name}
+                            // eslint-disable-next-line react/no-array-index-key
+                            key={index}
                             value={value}
                             onDelete={() => {
                               const newValues = [...field.value];

--- a/src/components/material/material-form/types.ts
+++ b/src/components/material/material-form/types.ts
@@ -1,20 +1,18 @@
 import { type IAttribute } from '@/components/attribute/constants';
 
+import { type IValue } from '@/types/material';
+
 export interface IFormData {
   name: string;
-  materialNumber: string;
-  netoPrice: string;
-  mwSt: string;
-  weight: string;
-  customsTariff: string;
-  comment: string;
-  packaging: boolean;
+  type: string;
+  values: IValue[];
   attributes: IAttribute[];
-  values: {
-    name: string;
-    value: string;
-    unit: string;
-    toleranceMin: number;
-    toleranceMax: number;
-  }[];
+  weight?: number;
+  materialNumber: string;
+  netPrice?: number;
+  VAT?: number;
+  customsTarif?: number;
+  description: string;
+  image: string;
+  packaging: boolean;
 }

--- a/src/components/value/value-row/value-row.tsx
+++ b/src/components/value/value-row/value-row.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useEffect, useCallback } from 'react';
+import { useCallback } from 'react';
 
 import {
   Box,
@@ -10,86 +10,47 @@ import {
 
 import { Input } from '@/shared/input';
 
+import { type IValue } from '@/types/material';
+
 import MenuIcon from '@/assets/icon/menu.svg?react';
 import DeleteIcon from '@/assets/icon/delete.svg?react';
 
 import { useStyles } from './styles';
 
 interface IValueRowProps {
-  value: {
-    name: string;
-    value: string;
-    unit: string;
-    toleranceMin: number;
-    toleranceMax: number;
-  };
+  value: IValue;
   onDelete: () => void;
-  onChange: (updatedValue: {
-    name: string;
-    value: string;
-    unit: string;
-    toleranceMin: number;
-    toleranceMax: number;
-  }) => void;
+  onChange: (updatedValue: IValue) => void;
 }
 
 export function ValueRow({
-  value,
+  value: valueProp,
   onDelete,
   onChange,
 }: IValueRowProps): React.ReactNode {
   const { classes } = useStyles();
-  const [localValue, setLocalValue] = useState(value);
-  const unitOptions = useMemo(() => {
-    return ['kg', 'g', 'm', 'cm'];
-  }, []);
+  const unitOptions = ['kg', 'g', 'm', 'cm'];
 
-  useEffect(() => {
-    setLocalValue(value);
-  }, [value]);
-
-  const updateValue = useCallback(
-    (updatedValue: {
-      name: string;
-      value: string;
-      unit: string;
-      toleranceMin: number;
-      toleranceMax: number;
-    }) => {
-      setLocalValue(updatedValue);
-      onChange(updatedValue);
+  const handleChange = useCallback(
+    (field: keyof IValue, newValue: string | number) => {
+      onChange({ ...valueProp, [field]: newValue });
     },
-    [onChange],
+    [onChange, valueProp],
   );
 
-  function handleNameChange(e: React.ChangeEvent<HTMLInputElement>): void {
-    updateValue({ ...localValue, name: e.target.value });
-  }
+  function handleInputChange(
+    field: keyof IValue,
+  ): (e: React.ChangeEvent<HTMLInputElement>) => void {
+    return (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value =
+        field === 'value' ||
+        field === 'toleranceMin' ||
+        field === 'toleranceMax'
+          ? Number(e.target.value)
+          : e.target.value;
 
-  function handleValueChange(e: React.ChangeEvent<HTMLInputElement>): void {
-    updateValue({ ...localValue, value: e.target.value });
-  }
-
-  function handleUnitChange(e: SelectChangeEvent<string>): void {
-    updateValue({ ...localValue, unit: e.target.value });
-  }
-
-  function handleToleranceMinChange(
-    e: React.ChangeEvent<HTMLInputElement>,
-  ): void {
-    updateValue({
-      ...localValue,
-      toleranceMin: Number.parseFloat(e.target.value),
-    });
-  }
-
-  function handleToleranceMaxChange(
-    e: React.ChangeEvent<HTMLInputElement>,
-  ): void {
-    updateValue({
-      ...localValue,
-      toleranceMax: Number.parseFloat(e.target.value),
-    });
+      handleChange(field, Number.isNaN(value) ? e.target.value : value);
+    };
   }
 
   return (
@@ -102,26 +63,25 @@ export function ValueRow({
       <Input
         placeholder="Name"
         name="name"
-        value={localValue.name}
-        onChange={handleNameChange}
+        value={valueProp.name}
+        onChange={handleInputChange('name')}
       />
       <Input
         placeholder="Value"
         name="value"
-        value={localValue.value}
-        onChange={handleValueChange}
+        type="number"
+        min={0}
+        max={999_999}
+        value={valueProp.value}
+        onChange={handleInputChange('value')}
       />
       <Select
-        value={localValue.unit}
-        onChange={handleUnitChange}
+        value={valueProp.unit}
+        onChange={(e: SelectChangeEvent<string>) => {
+          handleChange('unit', e.target.value);
+        }}
         className={classes.select}
         displayEmpty
-        renderValue={(selected) => {
-          if (!selected) {
-            return 'Select';
-          }
-          return selected;
-        }}
       >
         {unitOptions.map((unit) => {
           return (
@@ -137,8 +97,8 @@ export function ValueRow({
         type="number"
         min={0}
         max={999_999}
-        value={localValue.toleranceMin}
-        onChange={handleToleranceMinChange}
+        value={valueProp.toleranceMin}
+        onChange={handleInputChange('toleranceMin')}
       />
       <Input
         placeholder="Tolerance Max"
@@ -146,8 +106,8 @@ export function ValueRow({
         type="number"
         min={0}
         max={999_999}
-        value={localValue.toleranceMax}
-        onChange={handleToleranceMaxChange}
+        value={valueProp.toleranceMax}
+        onChange={handleInputChange('toleranceMax')}
       />
       <Box className={classes.iconButton}>
         <IconButton onClick={onDelete}>

--- a/src/pages/add-material-page/add-material-page.tsx
+++ b/src/pages/add-material-page/add-material-page.tsx
@@ -1,6 +1,8 @@
 import { useRef } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 
+import { MaterialAPI } from '@/services/material/api';
+
 import { Box } from '@mui/material';
 
 import { Button } from '@/shared/button';
@@ -11,7 +13,7 @@ import { type IFormData } from '@/components/material/material-form/types';
 import { Header } from '@/layouts/header';
 import { FormHeader } from '@/layouts/form-header';
 
-import { MaterialType } from '@/types/material';
+import { MaterialType, type IMaterial } from '@/types/material';
 
 import AddIcon from '@/assets/icon/add.svg?react';
 
@@ -35,11 +37,20 @@ export default function AddMaterialPage(): React.ReactNode {
     state?.materialType ?? MaterialType.Product;
   const config = materialConfig[materialType];
 
-  // eslint-disable-next-line unicorn/consistent-function-scoping
-  function handleSubmit(data: IFormData): void {
-    //TODO
-    // eslint-disable-next-line no-console
-    console.log('Form Data:', data);
+  async function handleSubmit(data: IFormData): Promise<void> {
+    try {
+      const extendedData = {
+        ...data,
+        type: materialType,
+        manufacturingParts: [],
+        purchasingParts: [],
+      };
+      await MaterialAPI.createMaterial(extendedData as IMaterial);
+      navigate('/material');
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Error creating material:', error);
+    }
   }
 
   function handleButtonClick(): void {
@@ -74,7 +85,12 @@ export default function AddMaterialPage(): React.ReactNode {
           </Box>
         }
       />
-      <MaterialForm onSubmit={handleSubmit} ref={formRef} />
+      <MaterialForm
+        onSubmit={async (data) => {
+          await handleSubmit(data);
+        }}
+        ref={formRef}
+      />
     </Box>
   );
 }

--- a/src/pages/add-material-page/add-material-page.tsx
+++ b/src/pages/add-material-page/add-material-page.tsx
@@ -1,15 +1,13 @@
 import { useRef } from 'react';
-import { useMutation } from '@tanstack/react-query';
 import { useNavigate, useLocation } from 'react-router-dom';
 
-import { MaterialAPI } from '@/services/material/api';
+import { useCreateMaterial } from '@/services/material/hooks';
 
 import { Box } from '@mui/material';
 
 import { Button } from '@/shared/button';
 
 import { MaterialForm } from '@/components/material/material-form';
-import { type IFormData } from '@/components/material/material-form/types';
 
 import { Header } from '@/layouts/header';
 import { FormHeader } from '@/layouts/form-header';
@@ -38,24 +36,7 @@ export default function AddMaterialPage(): React.ReactNode {
     state?.materialType ?? MaterialType.Product;
   const config = materialConfig[materialType];
 
-  const mutation = useMutation({
-    mutationFn: async (data: IFormData) => {
-      const extendedData = {
-        ...data,
-        type: materialType,
-        manufacturingParts: [],
-        purchasingParts: [],
-      };
-      return await MaterialAPI.createMaterial(extendedData as IMaterial);
-    },
-    onSuccess: () => {
-      navigate('/material');
-    },
-    onError: (error) => {
-      // eslint-disable-next-line no-console
-      console.error('Error creating material:', error);
-    },
-  });
+  const mutation = useCreateMaterial();
 
   function handleButtonClick(): void {
     if (formRef.current) {
@@ -91,7 +72,13 @@ export default function AddMaterialPage(): React.ReactNode {
       />
       <MaterialForm
         onSubmit={(data) => {
-          mutation.mutate(data);
+          mutation.mutate({
+            ...data,
+            type: materialType,
+            manufacturingParts: [],
+            purchasingParts: [],
+          } as IMaterial);
+          navigate('/material');
         }}
         ref={formRef}
       />

--- a/src/pages/add-material-page/add-material-page.tsx
+++ b/src/pages/add-material-page/add-material-page.tsx
@@ -1,4 +1,5 @@
 import { useRef } from 'react';
+import { useMutation } from '@tanstack/react-query';
 import { useNavigate, useLocation } from 'react-router-dom';
 
 import { MaterialAPI } from '@/services/material/api';
@@ -37,21 +38,24 @@ export default function AddMaterialPage(): React.ReactNode {
     state?.materialType ?? MaterialType.Product;
   const config = materialConfig[materialType];
 
-  async function handleSubmit(data: IFormData): Promise<void> {
-    try {
+  const mutation = useMutation({
+    mutationFn: async (data: IFormData) => {
       const extendedData = {
         ...data,
         type: materialType,
         manufacturingParts: [],
         purchasingParts: [],
       };
-      await MaterialAPI.createMaterial(extendedData as IMaterial);
+      return await MaterialAPI.createMaterial(extendedData as IMaterial);
+    },
+    onSuccess: () => {
       navigate('/material');
-    } catch (error) {
+    },
+    onError: (error) => {
       // eslint-disable-next-line no-console
       console.error('Error creating material:', error);
-    }
-  }
+    },
+  });
 
   function handleButtonClick(): void {
     if (formRef.current) {
@@ -86,8 +90,8 @@ export default function AddMaterialPage(): React.ReactNode {
         }
       />
       <MaterialForm
-        onSubmit={async (data) => {
-          await handleSubmit(data);
+        onSubmit={(data) => {
+          mutation.mutate(data);
         }}
         ref={formRef}
       />

--- a/src/services/material/api.ts
+++ b/src/services/material/api.ts
@@ -23,6 +23,15 @@ async function getAll(
   };
 }
 
+async function createMaterial(
+  data: IMaterial,
+): Promise<IApiResponse<IMaterial>> {
+  const response = await api.post<IApiResponse<IMaterial>>(endpoint, data);
+
+  return response.data;
+}
+
 export const MaterialAPI = {
   getAll,
+  createMaterial,
 };

--- a/src/services/material/api.ts
+++ b/src/services/material/api.ts
@@ -23,9 +23,7 @@ async function getAll(
   };
 }
 
-async function createMaterial(
-  data: IMaterial,
-): Promise<IApiResponse<IMaterial>> {
+async function create(data: IMaterial): Promise<IApiResponse<IMaterial>> {
   const response = await api.post<IApiResponse<IMaterial>>(endpoint, data);
 
   return response.data;
@@ -33,5 +31,5 @@ async function createMaterial(
 
 export const MaterialAPI = {
   getAll,
-  createMaterial,
+  create,
 };

--- a/src/services/material/hooks.ts
+++ b/src/services/material/hooks.ts
@@ -1,12 +1,15 @@
 import {
   useQuery,
+  useMutation,
   keepPreviousData,
   type UseQueryResult,
+  type UseMutationResult,
 } from '@tanstack/react-query';
 
 import { type IProduct } from '@/components/material/material-table/types';
 
 import { type IApiResponse } from '@/types/api';
+import { type IMaterial } from '@/types/material';
 
 import { MaterialAPI } from './api';
 
@@ -21,5 +24,17 @@ export function useMaterial(
       return MaterialAPI.getAll(params);
     },
     placeholderData: keepPreviousData,
+  });
+}
+
+export function useCreateMaterial(): UseMutationResult<
+  IApiResponse<IMaterial>,
+  Error,
+  IMaterial
+> {
+  return useMutation({
+    mutationFn: async (data: IMaterial) => {
+      return await MaterialAPI.create(data);
+    },
   });
 }


### PR DESCRIPTION
- added createMaterial
- changed types to arrange with BE
- ValueRow cleanup

NOTE: currently we dont have implemented in BE logic for fetching the multiple materialtype data, so manufactoringparts and purchasing parts are stored as emtpy, also in FE we need https://github.com/valens-dev/zen-fe/pull/34 to be able to send material data